### PR TITLE
Mark promoted constructor properties as readonly

### DIFF
--- a/src/ConsoleCommand/ClickhouseMigrateCommand.php
+++ b/src/ConsoleCommand/ClickhouseMigrateCommand.php
@@ -37,8 +37,8 @@ final class ClickhouseMigrateCommand extends Command
                 {--step= : Number of migrations to run}';
 
     public function __construct(
-        private Migrator $migrator,
-        private AppConfigRepositoryInterface $appConfig,
+        private readonly Migrator $migrator,
+        private readonly AppConfigRepositoryInterface $appConfig,
     ) {
         parent::__construct();
     }

--- a/src/ConsoleCommand/MakeClickhouseMigrationCommand.php
+++ b/src/ConsoleCommand/MakeClickhouseMigrationCommand.php
@@ -64,9 +64,9 @@ final class MakeClickhouseMigrationCommand extends Command
     }
 
     public function __construct(
-        private MigrationCreator $migrationCreator,
-        private Composer $composer,
-        private AppConfigRepositoryInterface $appConfigRepository,
+        private readonly MigrationCreator $migrationCreator,
+        private readonly Composer $composer,
+        private readonly AppConfigRepositoryInterface $appConfigRepository,
     ) {
         parent::__construct();
     }

--- a/src/Factory/ClickhouseClientFactory.php
+++ b/src/Factory/ClickhouseClientFactory.php
@@ -19,7 +19,7 @@ use Cog\Laravel\Clickhouse\Exception\ClickhouseConfigException;
 final class ClickhouseClientFactory
 {
     public function __construct(
-        private array $defaultConfig,
+        private readonly array $defaultConfig,
     ) {}
 
     /**

--- a/src/Migration/MigrationCreator.php
+++ b/src/Migration/MigrationCreator.php
@@ -18,8 +18,8 @@ use Illuminate\Filesystem\Filesystem;
 class MigrationCreator
 {
     public function __construct(
-        private Filesystem $filesystem,
-        private ?string $migrationStubFilePath,
+        private readonly Filesystem $filesystem,
+        private readonly ?string $migrationStubFilePath,
     ) {}
 
     public function create(

--- a/src/Migration/MigrationRepository.php
+++ b/src/Migration/MigrationRepository.php
@@ -19,8 +19,8 @@ use ClickHouseDB\Statement;
 final class MigrationRepository
 {
     public function __construct(
-        private Client $client,
-        private string $table,
+        private readonly Client $client,
+        private readonly string $table,
     ) {}
 
     /**

--- a/src/Migration/Migrator.php
+++ b/src/Migration/Migrator.php
@@ -28,9 +28,9 @@ use function in_array;
 final class Migrator
 {
     public function __construct(
-        private Client $client,
-        private MigrationRepository $repository,
-        private Filesystem $filesystem,
+        private readonly Client $client,
+        private readonly MigrationRepository $repository,
+        private readonly Filesystem $filesystem,
     ) {}
 
     /**


### PR DESCRIPTION
Adds `readonly` to all promoted constructor properties across the package:

- `ClickhouseMigrateCommand`
- `MakeClickhouseMigrationCommand`
- `ClickhouseClientFactory`
- `MigrationCreator`
- `MigrationRepository`
- `Migrator`

All of these are immutable collaborators assigned once at construction time, so `readonly` makes the intent explicit and lets the engine enforce it.

## Backward compatibility

No breaking changes:

- All affected properties are `private`, so they were never part of the public API.
- None of them are reassigned after construction, including `ClickhouseClientFactory::$defaultConfig` (in-place array writes would have been fatal under `readonly`).
- `MigrationCreator` is the only non-`final` class here; since its properties are `private`, a child class can still declare its own property with the same name without a redeclaration error.
- No `clone`, custom serialization, or reflection-based mutation targets these objects.
- `readonly` requires PHP 8.1+; the package already requires `^8.2`.