### PR TITLE
Use official ClickHouse server Docker image

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -49,7 +49,7 @@ services:
 
   clickhouse:
     container_name: laravel-clickhouse-clickhouse
-    image: yandex/clickhouse-server:21.8-alpine
+    image: clickhouse/clickhouse-server:21.9
     volumes:
       - ./.docker-volume-clickhouse:/var/lib/clickhouse
       - ./.docker/clickhouse/clickhouse-config.xml:/etc/clickhouse-server/config.d/logging.xml:ro


### PR DESCRIPTION
Replaces the deprecated `yandex/clickhouse-server:21.8-alpine` image with the official `clickhouse/clickhouse-server:21.9` image in the dev environment.

The `yandex/*` images are no longer published; `clickhouse/clickhouse-server` is their successor.

## Verification

- Container starts and reaches `healthy` state.
- Both mounted config overrides are applied: `config.d/logging.xml` (verified — no `system.*_log` tables) and `users.d/logging.xml` (verified — the `test` user authenticates).
- `SELECT version()` returns `21.9.6.24` over both HTTP (8123) and native client.
- The migration registry DDL (`ReplacingMergeTree` + `ORDER BY migration`), an insert and the `ORDER BY batch DESC, migration DESC` select all run successfully.
- `vendor/bin/phpunit` passes on php85 (2 tests, 8 assertions).